### PR TITLE
fix: 终端页面正确渲染 ComfyUI 日志中的 ANSI 颜色序列

### DIFF
--- a/source-code/frontend/src/components/common/AnsiLogMessage.tsx
+++ b/source-code/frontend/src/components/common/AnsiLogMessage.tsx
@@ -1,0 +1,56 @@
+/**
+ * ANSI 日志消息渲染组件
+ *
+ * 将携带 ANSI 颜色序列的日志文本渲染为带颜色/加粗样式的 span 片段，
+ * 用于终端页面还原 ComfyUI 等进程输出的真实终端配色。
+ * 不含 ANSI 序列的消息走快速路径，直接按纯文本渲染。
+ */
+
+import { parseAnsi, hasAnsi } from '@/utils/ansi'
+import { cn } from '@/lib/utils'
+
+// ANSI 16 色 -> Tailwind 类（深浅主题各自取可读的色阶）
+const ANSI_COLOR_CLASSES: Record<number, string> = {
+  0: 'text-neutral-500',
+  1: 'text-red-600 dark:text-red-400',
+  2: 'text-green-600 dark:text-green-400',
+  3: 'text-yellow-600 dark:text-yellow-300',
+  4: 'text-blue-600 dark:text-blue-400',
+  5: 'text-fuchsia-600 dark:text-fuchsia-400',
+  6: 'text-cyan-600 dark:text-cyan-400',
+  7: 'text-neutral-400 dark:text-neutral-300',
+  8: 'text-neutral-500',
+  9: 'text-red-500 dark:text-red-300',
+  10: 'text-green-500 dark:text-green-300',
+  11: 'text-yellow-500 dark:text-yellow-200',
+  12: 'text-blue-500 dark:text-blue-300',
+  13: 'text-fuchsia-500 dark:text-fuchsia-300',
+  14: 'text-cyan-500 dark:text-cyan-300',
+  15: 'text-neutral-600 dark:text-white'
+}
+
+interface AnsiLogMessageProps {
+  message: string
+}
+
+export function AnsiLogMessage({ message }: AnsiLogMessageProps) {
+  if (!hasAnsi(message)) {
+    return message
+  }
+  return parseAnsi(message).map((segment, index) => {
+    if (segment.colorIndex === undefined && !segment.bold) {
+      return <span key={index}>{segment.text}</span>
+    }
+    return (
+      <span
+        key={index}
+        className={cn(
+          segment.colorIndex !== undefined && ANSI_COLOR_CLASSES[segment.colorIndex],
+          segment.bold && 'font-bold'
+        )}
+      >
+        {segment.text}
+      </span>
+    )
+  })
+}

--- a/source-code/frontend/src/components/common/__tests__/AnsiLogMessage.test.tsx
+++ b/source-code/frontend/src/components/common/__tests__/AnsiLogMessage.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * AnsiLogMessage 组件测试
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { AnsiLogMessage } from '../AnsiLogMessage'
+
+const ESC = '\u001b'
+
+describe('AnsiLogMessage', () => {
+  it('纯文本消息原样渲染', () => {
+    const { container } = render(<AnsiLogMessage message="Total VRAM 16304 MB" />)
+    expect(container.textContent).toBe('Total VRAM 16304 MB')
+    expect(container.querySelector('span')).toBeNull()
+  })
+
+  it('ANSI 序列渲染为带色 span 且不残留控制码', () => {
+    const message = `${ESC}[32m[INFO]${ESC}[0m Adding extra search path`
+    const { container } = render(<AnsiLogMessage message={message} />)
+
+    expect(container.textContent).toBe('[INFO] Adding extra search path')
+
+    const colored = container.querySelector('span.text-green-600')
+    expect(colored).not.toBeNull()
+    expect(colored?.textContent).toBe('[INFO]')
+  })
+
+  it('加粗黄色 WARNING 标签', () => {
+    const message = `${ESC}[1m${ESC}[33m[WARNING]${ESC}[0m deprecated API`
+    const { container } = render(<AnsiLogMessage message={message} />)
+
+    expect(container.textContent).toBe('[WARNING] deprecated API')
+
+    const colored = container.querySelector('span.font-bold')
+    expect(colored).not.toBeNull()
+    expect(colored?.textContent).toBe('[WARNING]')
+    expect(colored?.className).toContain('text-yellow-600')
+  })
+})

--- a/source-code/frontend/src/pages/TerminalPage.tsx
+++ b/source-code/frontend/src/pages/TerminalPage.tsx
@@ -6,6 +6,8 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { toast } from '@/utils/toast'
+import { stripAnsi } from '@/utils/ansi'
+import { AnsiLogMessage } from '@/components/common/AnsiLogMessage'
 import { 
   Terminal, 
   Trash2, 
@@ -351,7 +353,7 @@ export default function TerminalPage() {
     }
     
     const logsText = logsToCopy
-      .map(log => `[${log.timestamp}] [${log.level}] ${log.message}`)
+      .map(log => `[${log.timestamp}] [${log.level}] ${stripAnsi(log.message)}`)
       .join('\n')
     
     navigator.clipboard.writeText(logsText)
@@ -441,7 +443,7 @@ export default function TerminalPage() {
         promptPrefix = `以下是 ComfyUI 运行过程中的错误日志（第 ${batchIndex + 1}/${totalBatches} 批），请帮我分析原因并提供解决方案：\n\n`
       }
       
-      const logsText = logs.map(log => `[${log.timestamp}] ${log.message}`).join('\n')
+      const logsText = logs.map(log => `[${log.timestamp}] ${stripAnsi(log.message)}`).join('\n')
       const messageContent = promptPrefix + logsText
       
       const systemPromptContent = comfyuiExpertPreset?.content || null
@@ -776,7 +778,7 @@ export default function TerminalPage() {
                     [{log.level}]
                   </span>
                   <span className={`flex-1 whitespace-pre-wrap break-all ${getLevelColor(log.level)}`}>
-                    {log.message}
+                    <AnsiLogMessage message={log.message} />
                   </span>
                 </div>
               </div>

--- a/source-code/frontend/src/utils/__tests__/ansi.test.ts
+++ b/source-code/frontend/src/utils/__tests__/ansi.test.ts
@@ -1,0 +1,127 @@
+/**
+ * ANSI 转义序列解析工具单元测试
+ *
+ * 样本取自 ComfyUI 与 Crystools 的真实日志输出
+ */
+
+import { describe, it, expect } from 'vitest'
+import { parseAnsi, stripAnsi, hasAnsi } from '../ansi'
+
+const ESC = '\u001b'
+
+describe('parseAnsi', () => {
+  it('不含 ANSI 序列时返回单个无样式片段', () => {
+    const text = 'Total VRAM 16304 MB, total RAM 48741 MB'
+    expect(parseAnsi(text)).toEqual([{ text }])
+  })
+
+  it('解析 ComfyUI INFO 级别标签（绿色）', () => {
+    const text = `${ESC}[32m[INFO]${ESC}[0m Adding extra search path llm`
+    expect(parseAnsi(text)).toEqual([
+      { text: '[INFO]', colorIndex: 2 },
+      { text: ' Adding extra search path llm' },
+    ])
+  })
+
+  it('解析 ComfyUI WARNING 级别标签（加粗黄色）', () => {
+    const text = `${ESC}[1m${ESC}[33m[WARNING]${ESC}[0m Some warning`
+    expect(parseAnsi(text)).toEqual([
+      { text: '[WARNING]', colorIndex: 3, bold: true },
+      { text: ' Some warning' },
+    ])
+  })
+
+  it('解析 Crystools 的组合参数序列 [0;32m', () => {
+    const text = `[Crystools ${ESC}[0;32mINFO${ESC}[0m] Crystools version: 1.27.4`
+    expect(parseAnsi(text)).toEqual([
+      { text: '[Crystools ' },
+      { text: 'INFO', colorIndex: 2 },
+      { text: '] Crystools version: 1.27.4' },
+    ])
+  })
+
+  it('解析亮色（90-97）', () => {
+    const text = `${ESC}[92mok${ESC}[0m done`
+    expect(parseAnsi(text)).toEqual([
+      { text: 'ok', colorIndex: 10 },
+      { text: ' done' },
+    ])
+  })
+
+  it('空参数序列等价于重置', () => {
+    const text = `${ESC}[31mred${ESC}[mplain`
+    expect(parseAnsi(text)).toEqual([
+      { text: 'red', colorIndex: 1 },
+      { text: 'plain' },
+    ])
+  })
+
+  it('39 恢复默认前景色, 22 取消加粗', () => {
+    const text = `${ESC}[1;31mbold red${ESC}[39m still bold${ESC}[22m plain`
+    expect(parseAnsi(text)).toEqual([
+      { text: 'bold red', colorIndex: 1, bold: true },
+      { text: ' still bold', bold: true },
+      { text: ' plain' },
+    ])
+  })
+
+  it('跳过 256 色扩展参数且不误读后续参数', () => {
+    const text = `${ESC}[38;5;196mextended${ESC}[0m`
+    expect(parseAnsi(text)).toEqual([{ text: 'extended' }])
+  })
+
+  it('跳过真彩色扩展参数', () => {
+    const text = `${ESC}[38;2;255;0;0mrgb${ESC}[0m`
+    expect(parseAnsi(text)).toEqual([{ text: 'rgb' }])
+  })
+
+  it('剥离非 SGR 的 CSI 序列（如清行）', () => {
+    const text = `${ESC}[2KProgress 50%`
+    expect(parseAnsi(text)).toEqual([{ text: 'Progress 50%' }])
+  })
+
+  it('剥离孤立的 ESC 字符', () => {
+    const text = `before${ESC}after`
+    expect(parseAnsi(text)).toEqual([{ text: 'beforeafter' }])
+  })
+
+  it('合并相邻同样式片段', () => {
+    const text = `${ESC}[32mgreen1${ESC}[32mgreen2${ESC}[0m`
+    expect(parseAnsi(text)).toEqual([{ text: 'green1green2', colorIndex: 2 }])
+  })
+
+  it('多行消息（Traceback 合并日志）保持换行', () => {
+    const text = `${ESC}[31mError line 1\nline 2${ESC}[0m`
+    expect(parseAnsi(text)).toEqual([{ text: 'Error line 1\nline 2', colorIndex: 1 }])
+  })
+
+  it('纯 ANSI 序列无文本时返回单个空片段', () => {
+    expect(parseAnsi(`${ESC}[32m${ESC}[0m`)).toEqual([{ text: '' }])
+  })
+})
+
+describe('stripAnsi', () => {
+  it('剥离全部 SGR 序列', () => {
+    const text = `${ESC}[1m${ESC}[33m[WARNING]${ESC}[0m Some warning`
+    expect(stripAnsi(text)).toBe('[WARNING] Some warning')
+  })
+
+  it('剥离非 SGR 序列与孤立 ESC', () => {
+    const text = `${ESC}[2Kline${ESC}`
+    expect(stripAnsi(text)).toBe('line')
+  })
+
+  it('纯文本原样返回', () => {
+    expect(stripAnsi('plain text')).toBe('plain text')
+  })
+})
+
+describe('hasAnsi', () => {
+  it('含 ESC 字符时为 true', () => {
+    expect(hasAnsi(`${ESC}[32mgreen${ESC}[0m`)).toBe(true)
+  })
+
+  it('纯文本为 false', () => {
+    expect(hasAnsi('[INFO] plain')).toBe(false)
+  })
+})

--- a/source-code/frontend/src/utils/ansi.ts
+++ b/source-code/frontend/src/utils/ansi.ts
@@ -1,0 +1,137 @@
+/**
+ * ANSI 转义序列解析工具
+ *
+ * ComfyUI 及部分插件（如 Crystools）的日志输出携带 ANSI SGR 颜色序列
+ * （如 \u001b[32m[INFO]\u001b[0m）。本模块将日志文本解析为带颜色/加粗
+ * 属性的片段，供终端页面按真实颜色渲染；同时提供 stripAnsi 用于复制、
+ * AI 分析等需要纯文本的场景。
+ *
+ * 支持的 SGR 参数：0（重置）、1（加粗）、22（取消加粗）、30-37（标准
+ * 前景色）、39（恢复默认前景色）、90-97（亮前景色）。38（扩展前景色）
+ * 与 48（扩展背景色）按 5;n / 2;r;g;b 形式正确跳过参数但不着色，其余
+ * 参数一律忽略。非 SGR 的 CSI 序列（光标控制等）直接剥离。
+ */
+
+// CSI 序列: ESC [ 参数字节 中间字节 终止字节
+// eslint-disable-next-line no-control-regex
+const CSI_PATTERN = /\u001b\[([0-9;]*)([\u0020-\u002f]*[\u0040-\u007e])/g
+
+// 孤立的 ESC 字符（未构成完整 CSI 序列）
+// eslint-disable-next-line no-control-regex
+const LONE_ESC_PATTERN = /\u001b/g
+
+export interface AnsiSegment {
+  text: string
+  /** ANSI 16 色索引: 0-7 标准色, 8-15 亮色 */
+  colorIndex?: number
+  bold?: boolean
+}
+
+interface SgrState {
+  colorIndex?: number
+  bold: boolean
+}
+
+/**
+ * 应用一条 SGR 序列的参数列表到当前状态
+ */
+function applySgrParams(params: string, state: SgrState): SgrState {
+  const next: SgrState = { ...state }
+  // 空参数串等价于 0（重置）
+  const codes = (params === '' ? '0' : params).split(';').map(p => (p === '' ? 0 : parseInt(p, 10)))
+
+  let i = 0
+  while (i < codes.length) {
+    const code = codes[i]
+    if (code === 0) {
+      next.colorIndex = undefined
+      next.bold = false
+    } else if (code === 1) {
+      next.bold = true
+    } else if (code === 22) {
+      next.bold = false
+    } else if (code >= 30 && code <= 37) {
+      next.colorIndex = code - 30
+    } else if (code === 39) {
+      next.colorIndex = undefined
+    } else if (code >= 90 && code <= 97) {
+      next.colorIndex = code - 90 + 8
+    } else if (code === 38 || code === 48) {
+      // 扩展色: 38;5;n 跳 2 个参数, 38;2;r;g;b 跳 4 个参数（不着色，只保证后续参数不被误读）
+      const mode = codes[i + 1]
+      if (mode === 5) {
+        i += 2
+      } else if (mode === 2) {
+        i += 4
+      }
+    }
+    // 其余参数（背景色、反显等）忽略
+    i += 1
+  }
+  return next
+}
+
+/**
+ * 将含 ANSI 序列的文本解析为带样式属性的片段数组。
+ * 相邻的同样式片段会被合并；不含 ANSI 序列时返回单片段。
+ */
+export function parseAnsi(text: string): AnsiSegment[] {
+  const segments: AnsiSegment[] = []
+  let state: SgrState = { bold: false }
+
+  const pushText = (chunk: string) => {
+    if (!chunk) {
+      return
+    }
+    const last = segments[segments.length - 1]
+    if (last && last.colorIndex === state.colorIndex && (last.bold ?? false) === state.bold) {
+      last.text += chunk
+      return
+    }
+    const segment: AnsiSegment = { text: chunk }
+    if (state.colorIndex !== undefined) {
+      segment.colorIndex = state.colorIndex
+    }
+    if (state.bold) {
+      segment.bold = true
+    }
+    segments.push(segment)
+  }
+
+  let lastIndex = 0
+  CSI_PATTERN.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = CSI_PATTERN.exec(text)) !== null) {
+    pushText(text.slice(lastIndex, match.index))
+    lastIndex = match.index + match[0].length
+
+    const [, params, finalByte] = match
+    if (finalByte === 'm') {
+      state = applySgrParams(params, state)
+    }
+    // 非 SGR 的 CSI 序列（光标控制等）直接丢弃
+  }
+  pushText(text.slice(lastIndex))
+
+  // 剥离残留的孤立 ESC 字符
+  for (const segment of segments) {
+    segment.text = segment.text.replace(LONE_ESC_PATTERN, '')
+  }
+
+  const result = segments.filter(segment => segment.text !== '')
+  return result.length > 0 ? result : [{ text: '' }]
+}
+
+/**
+ * 剥离文本中的全部 ANSI 序列，返回纯文本
+ */
+export function stripAnsi(text: string): string {
+  return text.replace(CSI_PATTERN, '').replace(LONE_ESC_PATTERN, '')
+}
+
+/**
+ * 判断文本是否包含 ANSI 转义序列（渲染快速路径用）
+ */
+export function hasAnsi(text: string): boolean {
+  return text.includes('\u001b')
+}


### PR DESCRIPTION
## 问题

ComfyUI 及部分插件 (如 Crystools) 的日志输出携带 ANSI SGR 颜色序列 (如 `ESC[32m[INFO]ESC[0m`). 终端页面此前按纯文本渲染, 不可见的 ESC 控制字符被丢弃后, 残留的 `[32m` / `[0m` 等片段显示为乱码:

```
[32m[INFO][0m Adding extra search path llm E:\...\models\llm
[1m[33m[WARNING][0m Detected import of deprecated legacy API...
[Crystools [0;32mINFO[0m] Crystools version: 1.27.4
```

## 修复方案

按真实终端配色渲染这些序列 (而非简单剥离):

- 新增 `utils/ansi.ts`: ANSI SGR 序列解析器
  - 支持 `0` 重置 / `1` 加粗 / `22` 取消加粗 / `30-37` 标准前景色 / `39` 恢复默认 / `90-97` 亮前景色
  - `38` / `48` 扩展色参数按 `5;n` / `2;r;g;b` 形式正确跳过, 保证后续参数不被误读
  - 非 SGR 的 CSI 序列 (光标控制等) 与孤立 ESC 字符直接剥离
  - 另导出 `stripAnsi` 供纯文本场景使用
- 新增 `components/common/AnsiLogMessage.tsx`: 把解析出的片段渲染为带色 span, ANSI 16 色映射到 Tailwind 类, 深浅主题各自取可读色阶; 不含 ANSI 序列的消息走快速路径直接渲染
- `TerminalPage.tsx` (仅 4 处功能改动):
  - 日志消息经 `AnsiLogMessage` 渲染
  - "一键复制日志" 与 "AI 分析" 改用 `stripAnsi` 后的纯文本, 避免控制码外泄到剪贴板与 AI 请求

## 效果 (v1.2.5 实机验证)

`[INFO]` 渲染为绿色, `[WARNING]` 加粗黄色, `[ERROR]` 红色, 无乱码残留:

![验证截图](https://raw.githubusercontent.com/hcwhan/ComfyNexus/pr-assets/terminal-ansi-colors-after.png)

## 测试与验证

- 新增 22 个单元/组件测试 (vitest + Testing Library), 样本取自 ComfyUI 与 Crystools 的真实日志输出, 全部通过
- `npx tsc --noEmit` 无错误; 新增文件 ESLint 零问题 (TerminalPage 既有的 5 个 `no-explicit-any` 与 2 个 hooks 警告未触碰)
- `npm run build` 生产构建通过
- 实机验证: 在 v1.2.5 安装目录替换 `_internal/dist` 后, 深浅主题下终端页面颜色渲染正常, 复制日志无控制码残留 (见上图)

纯前端改动, 不涉及后端与 pywebview API.
