### PR TITLE
fix: 打包 spec 的 pywebview 补丁移到 Analysis 之前，修复全新环境首次构建产物崩溃

### DIFF
--- a/source-code/build_exe.spec
+++ b/source-code/build_exe.spec
@@ -4,6 +4,112 @@ import sys
 
 block_cipher = None
 
+# ============================================
+# .NET 8 coreclr 源码预处理（必须在 Analysis 之前执行）
+# PyInstaller 在 Analysis() 阶段就会收集 pywebview 的 lib DLL，并把
+# winforms.py 编译为字节码放入 PYZ。此前这两段处理位于 Analysis 之后，
+# 修改只落在磁盘源文件上，首次构建（全新环境或 --clean 后缓存失效）的
+# 产物内嵌的仍是未修补版本：OpenFolderDialog 反射 .NET Framework 内部
+# 类型，在 .NET 8 下 import winforms 阶段即抛 AttributeError，应用启动
+# 直接崩溃；从第二次构建起才恰好正确。移到 Analysis 之前彻底消除该时序问题。
+# ============================================
+
+# 确保 pywebview lib 目录里是 netcoreapp3.0 版本的 WebView2 DLL
+# 直接替换源文件，让 PyInstaller hook 自然收集正确的版本
+import shutil as _shutil
+
+_netcore_dir = os.path.join('backend', 'lib', 'webview2_netcore')
+_webview_lib = os.path.join(os.path.abspath('.'), '.venv', 'Lib', 'site-packages', 'webview', 'lib')
+
+if os.path.isdir(_webview_lib) and os.path.isdir(_netcore_dir):
+    for _dll in ['Microsoft.Web.WebView2.Core.dll', 'Microsoft.Web.WebView2.WinForms.dll']:
+        _src = os.path.join(_netcore_dir, _dll)
+        _dst = os.path.join(_webview_lib, _dll)
+        if os.path.exists(_src):
+            _shutil.copy2(_src, _dst)
+            print(f"[spec] .NET 8: copied netcoreapp3.0 {_dll} to pywebview lib")
+
+    # 清理 .bak 备份文件
+    for _f in os.listdir(_webview_lib):
+        if _f.endswith('.bak'):
+            os.remove(os.path.join(_webview_lib, _f))
+            print(f"[spec] .NET 8: removed {_f}")
+
+# 直接 patch venv 中 pywebview 的 winforms.py
+# 该类的 OpenFolderDialog 使用反射访问 .NET Framework 内部类型，在 .NET 8 下不存在
+# 必须在打包前 patch 源文件，因为 PyInstaller 会编译 .pyc 打包进去
+import site
+_winforms_candidates = [
+    os.path.join(os.path.abspath('.'), '.venv', 'Lib', 'site-packages', 'webview', 'platforms', 'winforms.py'),
+]
+# 也搜索 site-packages
+for sp in site.getsitepackages() if hasattr(site, 'getsitepackages') else []:
+    _winforms_candidates.append(os.path.join(sp, 'webview', 'platforms', 'winforms.py'))
+
+for _wf_path in _winforms_candidates:
+    if os.path.exists(_wf_path):
+        with open(_wf_path, 'r', encoding='utf-8') as _f:
+            _wf_content = _f.read()
+        
+        if '# PATCHED_FOR_DOTNET8' in _wf_content:
+            print(f"[spec] .NET 8: winforms.py already patched: {_wf_path}")
+            break
+        
+        _modified = False
+
+        # Patch 1: 修复 _is_chromium 检测（精简版 Windows 没有 .NET Framework 注册表键）
+        _old_is_chromium = "is_chromium = not is_cef and _is_chromium() and forced_gui_ != 'mshtml'"
+        _new_is_chromium = "is_chromium = not is_cef and (forced_gui_ == 'edgechromium' or _is_chromium()) and forced_gui_ != 'mshtml'  # PATCHED_FOR_DOTNET8"
+        if _old_is_chromium in _wf_content:
+            _wf_content = _wf_content.replace(_old_is_chromium, _new_is_chromium)
+            _modified = True
+            print(f"[spec] .NET 8: Patched _is_chromium detection")
+
+        # Patch 2: 替换 OpenFolderDialog
+        if 'FileDialogNative+IFileDialog' in _wf_content:
+            _marker = "class OpenFolderDialog:"
+            if _marker in _wf_content:
+                _idx = _wf_content.index(_marker)
+                _rest = _wf_content[_idx:]
+                _lines = _rest.split('\n')
+                _end = len(_lines)
+                for _li, _ln in enumerate(_lines[1:], 1):
+                    _s = _ln.strip()
+                    if _ln and not _ln[0].isspace() and _s and not _s.startswith('#'):
+                        _end = _li
+                        break
+                
+                _repl = '''class OpenFolderDialog:  # PATCHED_FOR_DOTNET8
+    """Folder dialog compatible with .NET 8"""
+    foldersFilter = 'Folders|\\n'
+
+    @classmethod
+    def show(cls, parent=None, initialDirectory=None, allow_multiple=False, title=None):
+        dialog = WinForms.FolderBrowserDialog()
+        if initialDirectory:
+            dialog.SelectedPath = initialDirectory
+        if title:
+            dialog.Description = title
+        result = dialog.ShowDialog()
+        if result == WinForms.DialogResult.OK:
+            return (dialog.SelectedPath,)
+        return None
+
+'''
+                _wf_content = _wf_content[:_idx] + _repl + '\n'.join(_lines[_end:])
+                _modified = True
+                print(f"[spec] .NET 8: Patched OpenFolderDialog")
+
+        if _modified:
+            with open(_wf_path, 'w', encoding='utf-8') as _f:
+                _f.write(_wf_content)
+            _pycache = os.path.join(os.path.dirname(_wf_path), '__pycache__')
+            if os.path.exists(_pycache):
+                import shutil
+                shutil.rmtree(_pycache, ignore_errors=True)
+            print(f"[spec] .NET 8: winforms.py patched: {_wf_path}")
+        break
+
 a = Analysis(
     ['backend/main.py'],
     pathex=[os.path.abspath('.')],
@@ -162,109 +268,9 @@ def filter_bloat(items_list, item_type='datas'):
 a.datas = filter_bloat(a.datas, 'datas')
 a.binaries = filter_bloat(a.binaries, 'binaries')
 
-# ============================================
-# .NET 8 coreclr: 确保 pywebview lib 目录里是 netcoreapp3.0 版本的 WebView2 DLL
-# 直接替换源文件，让 PyInstaller hook 自然收集正确的版本
-# ============================================
-import shutil as _shutil
-
-_netcore_dir = os.path.join('backend', 'lib', 'webview2_netcore')
-_webview_lib = os.path.join(os.path.abspath('.'), '.venv', 'Lib', 'site-packages', 'webview', 'lib')
-
-if os.path.isdir(_webview_lib) and os.path.isdir(_netcore_dir):
-    for _dll in ['Microsoft.Web.WebView2.Core.dll', 'Microsoft.Web.WebView2.WinForms.dll']:
-        _src = os.path.join(_netcore_dir, _dll)
-        _dst = os.path.join(_webview_lib, _dll)
-        if os.path.exists(_src):
-            _shutil.copy2(_src, _dst)
-            print(f"[spec] .NET 8: copied netcoreapp3.0 {_dll} to pywebview lib")
-
-    # 清理 .bak 备份文件
-    for _f in os.listdir(_webview_lib):
-        if _f.endswith('.bak'):
-            os.remove(os.path.join(_webview_lib, _f))
-            print(f"[spec] .NET 8: removed {_f}")
-
 # 排除 .bak 文件（以防万一）
 a.binaries = [item for item in a.binaries if not item[0].endswith('.bak')]
 a.datas = [item for item in a.datas if not item[0].endswith('.bak')]
-
-# ============================================
-# .NET 8 coreclr: 直接 patch venv 中 pywebview 的 winforms.py
-# 该类的 OpenFolderDialog 使用反射访问 .NET Framework 内部类型，在 .NET 8 下不存在
-# 必须在打包前 patch 源文件，因为 PyInstaller 会编译 .pyc 打包进去
-# ============================================
-import site
-_winforms_candidates = [
-    os.path.join(os.path.abspath('.'), '.venv', 'Lib', 'site-packages', 'webview', 'platforms', 'winforms.py'),
-]
-# 也搜索 site-packages
-for sp in site.getsitepackages() if hasattr(site, 'getsitepackages') else []:
-    _winforms_candidates.append(os.path.join(sp, 'webview', 'platforms', 'winforms.py'))
-
-for _wf_path in _winforms_candidates:
-    if os.path.exists(_wf_path):
-        with open(_wf_path, 'r', encoding='utf-8') as _f:
-            _wf_content = _f.read()
-        
-        if '# PATCHED_FOR_DOTNET8' in _wf_content:
-            print(f"[spec] .NET 8: winforms.py already patched: {_wf_path}")
-            break
-        
-        _modified = False
-
-        # Patch 1: 修复 _is_chromium 检测（精简版 Windows 没有 .NET Framework 注册表键）
-        _old_is_chromium = "is_chromium = not is_cef and _is_chromium() and forced_gui_ != 'mshtml'"
-        _new_is_chromium = "is_chromium = not is_cef and (forced_gui_ == 'edgechromium' or _is_chromium()) and forced_gui_ != 'mshtml'  # PATCHED_FOR_DOTNET8"
-        if _old_is_chromium in _wf_content:
-            _wf_content = _wf_content.replace(_old_is_chromium, _new_is_chromium)
-            _modified = True
-            print(f"[spec] .NET 8: Patched _is_chromium detection")
-
-        # Patch 2: 替换 OpenFolderDialog
-        if 'FileDialogNative+IFileDialog' in _wf_content:
-            _marker = "class OpenFolderDialog:"
-            if _marker in _wf_content:
-                _idx = _wf_content.index(_marker)
-                _rest = _wf_content[_idx:]
-                _lines = _rest.split('\n')
-                _end = len(_lines)
-                for _li, _ln in enumerate(_lines[1:], 1):
-                    _s = _ln.strip()
-                    if _ln and not _ln[0].isspace() and _s and not _s.startswith('#'):
-                        _end = _li
-                        break
-                
-                _repl = '''class OpenFolderDialog:  # PATCHED_FOR_DOTNET8
-    """Folder dialog compatible with .NET 8"""
-    foldersFilter = 'Folders|\\n'
-
-    @classmethod
-    def show(cls, parent=None, initialDirectory=None, allow_multiple=False, title=None):
-        dialog = WinForms.FolderBrowserDialog()
-        if initialDirectory:
-            dialog.SelectedPath = initialDirectory
-        if title:
-            dialog.Description = title
-        result = dialog.ShowDialog()
-        if result == WinForms.DialogResult.OK:
-            return (dialog.SelectedPath,)
-        return None
-
-'''
-                _wf_content = _wf_content[:_idx] + _repl + '\n'.join(_lines[_end:])
-                _modified = True
-                print(f"[spec] .NET 8: Patched OpenFolderDialog")
-
-        if _modified:
-            with open(_wf_path, 'w', encoding='utf-8') as _f:
-                _f.write(_wf_content)
-            _pycache = os.path.join(os.path.dirname(_wf_path), '__pycache__')
-            if os.path.exists(_pycache):
-                import shutil
-                shutil.rmtree(_pycache, ignore_errors=True)
-            print(f"[spec] .NET 8: winforms.py patched: {_wf_path}")
-        break
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 

--- a/source-code/build_exe_debug.spec
+++ b/source-code/build_exe_debug.spec
@@ -4,6 +4,112 @@ import sys
 
 block_cipher = None
 
+# ============================================
+# .NET 8 coreclr 源码预处理（必须在 Analysis 之前执行）
+# PyInstaller 在 Analysis() 阶段就会收集 pywebview 的 lib DLL，并把
+# winforms.py 编译为字节码放入 PYZ。此前这两段处理位于 Analysis 之后，
+# 修改只落在磁盘源文件上，首次构建（全新环境或 --clean 后缓存失效）的
+# 产物内嵌的仍是未修补版本：OpenFolderDialog 反射 .NET Framework 内部
+# 类型，在 .NET 8 下 import winforms 阶段即抛 AttributeError，应用启动
+# 直接崩溃；从第二次构建起才恰好正确。移到 Analysis 之前彻底消除该时序问题。
+# ============================================
+
+# 确保 pywebview lib 目录里是 netcoreapp3.0 版本的 WebView2 DLL
+# 直接替换源文件，让 PyInstaller hook 自然收集正确的版本
+import shutil as _shutil
+
+_netcore_dir = os.path.join('backend', 'lib', 'webview2_netcore')
+_webview_lib = os.path.join(os.path.abspath('.'), '.venv', 'Lib', 'site-packages', 'webview', 'lib')
+
+if os.path.isdir(_webview_lib) and os.path.isdir(_netcore_dir):
+    for _dll in ['Microsoft.Web.WebView2.Core.dll', 'Microsoft.Web.WebView2.WinForms.dll']:
+        _src = os.path.join(_netcore_dir, _dll)
+        _dst = os.path.join(_webview_lib, _dll)
+        if os.path.exists(_src):
+            _shutil.copy2(_src, _dst)
+            print(f"[spec] .NET 8: copied netcoreapp3.0 {_dll} to pywebview lib")
+
+    # 清理 .bak 备份文件
+    for _f in os.listdir(_webview_lib):
+        if _f.endswith('.bak'):
+            os.remove(os.path.join(_webview_lib, _f))
+            print(f"[spec] .NET 8: removed {_f}")
+
+# 直接 patch venv 中 pywebview 的 winforms.py
+# 该类的 OpenFolderDialog 使用反射访问 .NET Framework 内部类型，在 .NET 8 下不存在
+# 必须在打包前 patch 源文件，因为 PyInstaller 会编译 .pyc 打包进去
+import site
+_winforms_candidates = [
+    os.path.join(os.path.abspath('.'), '.venv', 'Lib', 'site-packages', 'webview', 'platforms', 'winforms.py'),
+]
+# 也搜索 site-packages
+for sp in site.getsitepackages() if hasattr(site, 'getsitepackages') else []:
+    _winforms_candidates.append(os.path.join(sp, 'webview', 'platforms', 'winforms.py'))
+
+for _wf_path in _winforms_candidates:
+    if os.path.exists(_wf_path):
+        with open(_wf_path, 'r', encoding='utf-8') as _f:
+            _wf_content = _f.read()
+        
+        if '# PATCHED_FOR_DOTNET8' in _wf_content:
+            print(f"[spec] .NET 8: winforms.py already patched: {_wf_path}")
+            break
+        
+        _modified = False
+
+        # Patch 1: 修复 _is_chromium 检测（精简版 Windows 没有 .NET Framework 注册表键）
+        _old_is_chromium = "is_chromium = not is_cef and _is_chromium() and forced_gui_ != 'mshtml'"
+        _new_is_chromium = "is_chromium = not is_cef and (forced_gui_ == 'edgechromium' or _is_chromium()) and forced_gui_ != 'mshtml'  # PATCHED_FOR_DOTNET8"
+        if _old_is_chromium in _wf_content:
+            _wf_content = _wf_content.replace(_old_is_chromium, _new_is_chromium)
+            _modified = True
+            print(f"[spec] .NET 8: Patched _is_chromium detection")
+
+        # Patch 2: 替换 OpenFolderDialog
+        if 'FileDialogNative+IFileDialog' in _wf_content:
+            _marker = "class OpenFolderDialog:"
+            if _marker in _wf_content:
+                _idx = _wf_content.index(_marker)
+                _rest = _wf_content[_idx:]
+                _lines = _rest.split('\n')
+                _end = len(_lines)
+                for _li, _ln in enumerate(_lines[1:], 1):
+                    _s = _ln.strip()
+                    if _ln and not _ln[0].isspace() and _s and not _s.startswith('#'):
+                        _end = _li
+                        break
+                
+                _repl = '''class OpenFolderDialog:  # PATCHED_FOR_DOTNET8
+    """Folder dialog compatible with .NET 8"""
+    foldersFilter = 'Folders|\\n'
+
+    @classmethod
+    def show(cls, parent=None, initialDirectory=None, allow_multiple=False, title=None):
+        dialog = WinForms.FolderBrowserDialog()
+        if initialDirectory:
+            dialog.SelectedPath = initialDirectory
+        if title:
+            dialog.Description = title
+        result = dialog.ShowDialog()
+        if result == WinForms.DialogResult.OK:
+            return (dialog.SelectedPath,)
+        return None
+
+'''
+                _wf_content = _wf_content[:_idx] + _repl + '\n'.join(_lines[_end:])
+                _modified = True
+                print(f"[spec] .NET 8: Patched OpenFolderDialog")
+
+        if _modified:
+            with open(_wf_path, 'w', encoding='utf-8') as _f:
+                _f.write(_wf_content)
+            _pycache = os.path.join(os.path.dirname(_wf_path), '__pycache__')
+            if os.path.exists(_pycache):
+                import shutil
+                shutil.rmtree(_pycache, ignore_errors=True)
+            print(f"[spec] .NET 8: winforms.py patched: {_wf_path}")
+        break
+
 a = Analysis(
     ['backend/main.py'],
     pathex=[os.path.abspath('.')],
@@ -162,109 +268,9 @@ def filter_bloat(items_list, item_type='datas'):
 a.datas = filter_bloat(a.datas, 'datas')
 a.binaries = filter_bloat(a.binaries, 'binaries')
 
-# ============================================
-# .NET 8 coreclr: 确保 pywebview lib 目录里是 netcoreapp3.0 版本的 WebView2 DLL
-# 直接替换源文件，让 PyInstaller hook 自然收集正确的版本
-# ============================================
-import shutil as _shutil
-
-_netcore_dir = os.path.join('backend', 'lib', 'webview2_netcore')
-_webview_lib = os.path.join(os.path.abspath('.'), '.venv', 'Lib', 'site-packages', 'webview', 'lib')
-
-if os.path.isdir(_webview_lib) and os.path.isdir(_netcore_dir):
-    for _dll in ['Microsoft.Web.WebView2.Core.dll', 'Microsoft.Web.WebView2.WinForms.dll']:
-        _src = os.path.join(_netcore_dir, _dll)
-        _dst = os.path.join(_webview_lib, _dll)
-        if os.path.exists(_src):
-            _shutil.copy2(_src, _dst)
-            print(f"[spec] .NET 8: copied netcoreapp3.0 {_dll} to pywebview lib")
-
-    # 清理 .bak 备份文件
-    for _f in os.listdir(_webview_lib):
-        if _f.endswith('.bak'):
-            os.remove(os.path.join(_webview_lib, _f))
-            print(f"[spec] .NET 8: removed {_f}")
-
 # 排除 .bak 文件（以防万一）
 a.binaries = [item for item in a.binaries if not item[0].endswith('.bak')]
 a.datas = [item for item in a.datas if not item[0].endswith('.bak')]
-
-# ============================================
-# .NET 8 coreclr: 直接 patch venv 中 pywebview 的 winforms.py
-# 该类的 OpenFolderDialog 使用反射访问 .NET Framework 内部类型，在 .NET 8 下不存在
-# 必须在打包前 patch 源文件，因为 PyInstaller 会编译 .pyc 打包进去
-# ============================================
-import site
-_winforms_candidates = [
-    os.path.join(os.path.abspath('.'), '.venv', 'Lib', 'site-packages', 'webview', 'platforms', 'winforms.py'),
-]
-# 也搜索 site-packages
-for sp in site.getsitepackages() if hasattr(site, 'getsitepackages') else []:
-    _winforms_candidates.append(os.path.join(sp, 'webview', 'platforms', 'winforms.py'))
-
-for _wf_path in _winforms_candidates:
-    if os.path.exists(_wf_path):
-        with open(_wf_path, 'r', encoding='utf-8') as _f:
-            _wf_content = _f.read()
-        
-        if '# PATCHED_FOR_DOTNET8' in _wf_content:
-            print(f"[spec] .NET 8: winforms.py already patched: {_wf_path}")
-            break
-        
-        _modified = False
-
-        # Patch 1: 修复 _is_chromium 检测（精简版 Windows 没有 .NET Framework 注册表键）
-        _old_is_chromium = "is_chromium = not is_cef and _is_chromium() and forced_gui_ != 'mshtml'"
-        _new_is_chromium = "is_chromium = not is_cef and (forced_gui_ == 'edgechromium' or _is_chromium()) and forced_gui_ != 'mshtml'  # PATCHED_FOR_DOTNET8"
-        if _old_is_chromium in _wf_content:
-            _wf_content = _wf_content.replace(_old_is_chromium, _new_is_chromium)
-            _modified = True
-            print(f"[spec] .NET 8: Patched _is_chromium detection")
-
-        # Patch 2: 替换 OpenFolderDialog
-        if 'FileDialogNative+IFileDialog' in _wf_content:
-            _marker = "class OpenFolderDialog:"
-            if _marker in _wf_content:
-                _idx = _wf_content.index(_marker)
-                _rest = _wf_content[_idx:]
-                _lines = _rest.split('\n')
-                _end = len(_lines)
-                for _li, _ln in enumerate(_lines[1:], 1):
-                    _s = _ln.strip()
-                    if _ln and not _ln[0].isspace() and _s and not _s.startswith('#'):
-                        _end = _li
-                        break
-                
-                _repl = '''class OpenFolderDialog:  # PATCHED_FOR_DOTNET8
-    """Folder dialog compatible with .NET 8"""
-    foldersFilter = 'Folders|\\n'
-
-    @classmethod
-    def show(cls, parent=None, initialDirectory=None, allow_multiple=False, title=None):
-        dialog = WinForms.FolderBrowserDialog()
-        if initialDirectory:
-            dialog.SelectedPath = initialDirectory
-        if title:
-            dialog.Description = title
-        result = dialog.ShowDialog()
-        if result == WinForms.DialogResult.OK:
-            return (dialog.SelectedPath,)
-        return None
-
-'''
-                _wf_content = _wf_content[:_idx] + _repl + '\n'.join(_lines[_end:])
-                _modified = True
-                print(f"[spec] .NET 8: Patched OpenFolderDialog")
-
-        if _modified:
-            with open(_wf_path, 'w', encoding='utf-8') as _f:
-                _f.write(_wf_content)
-            _pycache = os.path.join(os.path.dirname(_wf_path), '__pycache__')
-            if os.path.exists(_pycache):
-                import shutil
-                shutil.rmtree(_pycache, ignore_errors=True)
-            print(f"[spec] .NET 8: winforms.py patched: {_wf_path}")
-        break
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 


### PR DESCRIPTION
## 问题

`build_exe.spec` / `build_exe_debug.spec` 中对 pywebview 的两段源码预处理写在 `Analysis()` **之后**：

1. 把 netcoreapp3.0 版本的 WebView2 DLL 复制进 pywebview 的 `lib` 目录
2. patch `winforms.py`（替换 `OpenFolderDialog`、修正 `_is_chromium` 检测，用于 .NET 8 coreclr 兼容）

但 PyInstaller 在 `Analysis()` 阶段就已收集 DLL 并把 `winforms.py` 编译为字节码放入 PYZ，之后的修改只落在磁盘源文件上，**对本次构建产物不生效**。

## 后果

全新构建环境（新克隆仓库 + 新建 venv）的**首次构建**产物内嵌的是未修补的 winforms 字节码。`OpenFolderDialog` 类体使用反射访问 .NET Framework 内部类型 `FileDialogNative+IFileDialog`，在 .NET 8 coreclr 下模块 import 阶段即崩溃：

```
File "webview\platforms\winforms.py", line 680, in OpenFolderDialog
AttributeError: 'NoneType' object has no attribute 'GetMethod'
```

由于生产版隐藏控制台，表现为：应用启动后无窗口、托盘图标短暂出现后消失，无任何错误提示。

从**第二次**构建起，venv 源文件已被上一次构建修补，产物才恰好正确——这使问题极具迷惑性：长期使用同一构建环境不会踩到，而新环境（新维护者、CI、重装依赖后）首次构建必踩。我在本机全新 venv 中复现并确认了该行为（首次构建产物崩溃，重复构建后正常）。

## 修复

将两段预处理整体移到 `Analysis()` 之前执行，首次构建即生效。逻辑本身未改动，仅调整执行顺序，两个 spec 文件同步修改（二者仅 `console` 参数不同）。

## 验证

对全新安装的 pywebview 6.2.1 执行首次 `--clean` 构建，通过扫描产物 exe 内嵌字节码确认：

- 修复前：首次构建产物包含 `FileDialogNative`（未修补），运行即崩溃
- 修复后：首次构建产物即包含 `FolderBrowserDialog`（已修补）与 netcoreapp3.0 DLL（哈希与 `backend/lib/webview2_netcore` 一致），运行正常
