### PR TITLE
fix: 修复托盘菜单"退出应用"受关闭按钮配置拦截导致无法退出的问题

### DIFF
--- a/source-code/backend/main.py
+++ b/source-code/backend/main.py
@@ -835,14 +835,12 @@ def main():
     
     def tray_exit_app():
         """托盘退出应用回调"""
+        # 与关闭确认弹窗中"关闭程序"走同一退出路径：api.closeApp() 会先设置
+        # _app_exit_requested 放行 on_window_closing 的 closeBehavior 拦截。
+        # 此前直接 window.destroy() 会被该拦截按关闭按钮配置处理，导致
+        # minimize 配置下退不出去、每次询问配置下弹出确认框。
         try:
-            floating_window_manager.destroy()
-            if hasattr(api, '_comfyui_process') and api._comfyui_process:
-                if api._comfyui_process.is_running:
-                    api._comfyui_process.stop()
-            api._system_monitor_controller.close()
-            system_tray_manager.destroy()
-            window.destroy()
+            api.closeApp()
             logger.info("[TrayCallback] 应用已退出")
         except Exception as e:
             logger.error(f"[TrayCallback] 退出应用失败: {e}")


### PR DESCRIPTION
## 问题描述

系统托盘右键菜单的"退出应用"行为受"系统设置 → 关闭按钮操作"配置影响，无法正常退出：

1. 配置为**最小化到托盘**时，点击"退出应用"：窗口显示时只是窗口消失、进程未退出；窗口已隐藏时则完全无反应
2. 配置为**每次询问**时，点击"退出应用"：弹出关闭确认对话框，而不是直接退出
3. 仅配置为**关闭程序**时能正常退出

## 原因分析

`tray_exit_app` 回调直接调用 `window.destroy()`。pywebview 销毁窗口时会触发 `closing` 事件，被 `main.py` 中为拦截 ALT+F4 注册的 `on_window_closing` 处理器截获。该处理器不知道这是托盘发出的明确退出指令（放行标志 `_app_exit_requested` 未被设置），于是按 `closeBehavior` 配置处理：`minimize` 配置下隐藏窗口并取消关闭，"每次询问"配置下触发前端确认弹窗并取消关闭，导致程序退不出去。

## 修复方案

让托盘"退出应用"与关闭确认弹窗中的"关闭程序"按钮走完全相同的退出路径——直接调用 `api.closeApp()`。该方法会先设置 `_app_exit_requested = True` 放行 `on_window_closing` 拦截，再依次清理悬浮窗、托盘图标、ComfyUI 进程、硬件监控，最后发送 `WM_CLOSE` 关闭窗口。原先 `tray_exit_app` 中手写的清理序列与 `closeApp()` 内部完全重复，一并移除。

修复后，无论关闭按钮操作配置为何值、窗口处于显示还是隐藏状态，托盘"退出应用"都直接退出程序。

## 测试

- 三种"关闭按钮操作"配置（关闭程序 / 最小化到托盘 / 每次询问）下，托盘右键"退出应用"均直接退出
- 窗口最小化到托盘（隐藏）状态下，托盘右键"退出应用"正常退出
- 关闭按钮（X）原有行为不受影响：每次询问时弹窗、弹窗中选择"关闭"正常退出
