### PR TITLE
fix: 修复 ALT+F4 关闭询问弹窗取消后标志未复位导致再次关闭跳过询问的问题

### DIFF
--- a/source-code/backend/main.py
+++ b/source-code/backend/main.py
@@ -896,12 +896,16 @@ def main():
     # 拦截 ALT+F4 等操作系统级别的窗口关闭事件
     # 使行为与前端 X 按钮一致：根据用户偏好最小化到托盘或退出
     _is_exiting = False
-    _dialog_pending = False
     
     def on_window_closing():
-        nonlocal _is_exiting, _dialog_pending
-        if _is_exiting or _dialog_pending or api._app_exit_requested:
+        nonlocal _is_exiting
+        if _is_exiting or api._app_exit_requested:
             return True
+        
+        # 询问弹窗展示期间的重复关闭请求一律忽略，避免绕过询问直接退出。
+        # 弹窗关闭时前端会调用 resetCloseDialogState() 复位该标志。
+        if api._close_dialog_pending:
+            return False
         
         try:
             result = api._settings_manager.get_settings()
@@ -927,11 +931,17 @@ def main():
                         system_tray_manager.destroy()
                         return True
             
-            _dialog_pending = True
-            _is_exiting = True
-            threading.Timer(0.1, lambda: window.evaluate_js(
-                'window.triggerCloseDialog && window.triggerCloseDialog()'
-            )).start()
+            api._close_dialog_pending = True
+            
+            def _show_close_dialog():
+                try:
+                    window.evaluate_js('window.triggerCloseDialog && window.triggerCloseDialog()')
+                except Exception as e:
+                    # 弹窗触发失败时复位标志，避免后续 ALT+F4 被永久忽略
+                    api._close_dialog_pending = False
+                    logger.error(f"[Closing] 触发关闭确认弹窗失败: {e}")
+            
+            threading.Timer(0.1, _show_close_dialog).start()
             return False
         except Exception as e:
             logger.error(f"[Closing] 处理关闭事件失败: {e}")

--- a/source-code/backend/src/bridge/api.py
+++ b/source-code/backend/src/bridge/api.py
@@ -45,6 +45,9 @@ class Api:
         self._dpi_scale = 1.0
         self._frontend_heartbeat_received = False
         self._app_exit_requested = False
+        # 关闭确认弹窗待处理标志：ALT+F4 等系统关闭请求被拦截并触发弹窗后置位，
+        # 置位期间忽略新的关闭请求；弹窗关闭时由前端调用 resetCloseDialogState() 复位
+        self._close_dialog_pending = False
         
         # 直接初始化所有控制器 - 使用私有属性命名
         from backend.src.core.config import ModuleConfigManager
@@ -383,6 +386,16 @@ class Api:
         except Exception as e:
             logger.error(f"[setCloseBehavior] 保存关闭行为设置失败: {str(e)}")
             return {"success": False, "message": str(e)}
+    
+    def resetCloseDialogState(self) -> dict:
+        """关闭确认弹窗已关闭时复位待处理标志
+
+        由前端在弹窗关闭时调用（无论选择最小化、直接关闭弹窗还是退出程序），
+        使后续 ALT+F4 能重新按 closeBehavior 配置处理。退出程序路径由
+        closeApp() 设置的 _app_exit_requested 放行，不受本复位影响。
+        """
+        self._close_dialog_pending = False
+        return {"success": True}
     
     def closeApp(self):
         """关闭应用"""

--- a/source-code/frontend/src/components/layout/TitleBar.tsx
+++ b/source-code/frontend/src/components/layout/TitleBar.tsx
@@ -408,6 +408,17 @@ export function TitleBar() {
     }
   }, [handleClose])
 
+  // 弹窗关闭时复位后端 ALT+F4 弹窗待处理标志（无论选择最小化、退出还是直接关闭弹窗）。
+  // 退出程序路径由 closeApp 设置的 _app_exit_requested 放行，不受此复位影响。
+  const handleCloseConfirmOpenChange = useCallback((open: boolean) => {
+    setShowCloseConfirm(open)
+    if (!open) {
+      bridgeService.resetCloseDialogState().catch((error) => {
+        console.error('[TitleBar] Failed to reset close dialog state:', error)
+      })
+    }
+  }, [])
+
   const handleCloseConfirm = async (dontAskAgain: boolean) => {
     console.log('[TitleBar] handleCloseConfirm called, dontAskAgain:', dontAskAgain)
     try {
@@ -874,7 +885,7 @@ export function TitleBar() {
       {/* 关闭确认对话框 */}
       <CloseConfirmDialog
         open={showCloseConfirm}
-        onOpenChange={setShowCloseConfirm}
+        onOpenChange={handleCloseConfirmOpenChange}
         onClose={handleCloseConfirm}
         onMinimize={handleMinimizeConfirm}
       />

--- a/source-code/frontend/src/services/bridge.ts
+++ b/source-code/frontend/src/services/bridge.ts
@@ -147,6 +147,16 @@ class BridgeService implements EnvironmentAPI {
   }
 
   /**
+   * Reset backend close-dialog pending flag (called when the close confirm dialog is dismissed)
+   */
+  async resetCloseDialogState(): Promise<{ success: boolean }> {
+    if (isDevelopment()) {
+      return { success: true };
+    }
+    return this.callApi<{ success: boolean }>('resetCloseDialogState');
+  }
+
+  /**
    * Minimize app
    */
   async minimizeApp() {


### PR DESCRIPTION
## 问题描述

关闭按钮操作配置为"每次询问"时，按 ALT+F4（或其他系统级关闭请求）会弹出关闭确认弹窗。如果在弹窗中选择"最小化到托盘"，或直接关闭弹窗（ESC / 点击遮罩），之后再按 ALT+F4 会跳过询问直接退出程序，不再弹出确认弹窗。

## 原因分析

`main.py` 的 `on_window_closing` 拦截器在"每次询问"路径会先置位 `_dialog_pending` 和 `_is_exiting` 两个标志再触发前端弹窗。但这两个标志只在用户选择"关闭程序"退出时才随进程结束消亡；选择"最小化到托盘"或取消弹窗时无人复位。拦截器入口的守卫 `if _is_exiting or _dialog_pending or ...: return True` 看到残留标志后直接放行关闭，导致后续 ALT+F4 绕过询问。

此外，弹窗展示期间再按 ALT+F4 同样命中该守卫直接退出，也绕过了询问。

## 修复方案

1. 后端 `api.py`：新增 `_close_dialog_pending` 标志（挂在 api 对象上，前端可触达），并新增 `resetCloseDialogState()` API 用于复位。
2. 后端 `main.py` 的 `on_window_closing`：
   - "每次询问"路径不再置位 `_is_exiting`（跳过询问的元凶），只置位 `api._close_dialog_pending`
   - 弹窗待处理期间的重复关闭请求从"直接放行退出"改为"忽略"，避免绕过询问
   - 触发前端弹窗的 JS 调用失败时自动复位标志，避免 ALT+F4 被永久忽略
3. 前端 `TitleBar.tsx` / `bridge.ts`：弹窗关闭时（选最小化、选退出或直接关闭弹窗）调用 `resetCloseDialogState()` 复位后端标志。选择"退出程序"的路径由 `closeApp()` 设置的 `_app_exit_requested` 放行，不受复位影响。

## 修复后行为

- ALT+F4 弹窗后选择"最小化到托盘"或取消弹窗，之后再按 ALT+F4 会重新按配置询问
- 弹窗展示期间重复按 ALT+F4 被忽略，不会绕过询问直接退出
- 各退出路径（弹窗选"关闭程序"、X 按钮、"关闭程序"配置下的 ALT+F4）行为不变

## 测试

- 后端 `py_compile` 通过；前端 `tsc -b` 类型检查通过
- 既有测试 `TitleBar.maximize.test.tsx` 的 4 个失败与本次改动无关（干净基线上失败相同，为测试环境 i18n 既有问题）
